### PR TITLE
No need for text mode in FTP.  Binary mode works for text always.

### DIFF
--- a/paas/README.md
+++ b/paas/README.md
@@ -23,7 +23,7 @@ Once you are done exploring the demo, you should delete the javaee-cafe-group-`<
 * In the portal, go to 'All resources'. Find and click on javaee-cafe-web-`<your suffix>`.
 * Go to the Deployment Center. Select FTP -> Dashboard -> User Credentials (note that FTP is just one deployment option in App Service). Enter wildfly as the username. Enter Secret12345! as the password. Click 'Save Credentials'.
 * Go to the Overview panel. Note down the FTP access information. Connect with your favorite FTP client.
-* Go to where this application is on your local machine. Got to the paas directory. Open the [jboss_cli_commands.cli](jboss_cli_commands.cli) in a text editor. Replace occurrences of `reza` with `<your suffix>`. Via FTP, upload the JDBC driver to the /site/deployments/tools/ directory *in binary mode*. Then upload the jboss_cli_commands.cli, postgresql-module.xml and startup.sh files *in text mode* to the /site/deployments/tools/ directory.
+* Go to where this application is on your local machine. Got to the paas directory. Open the [jboss_cli_commands.cli](jboss_cli_commands.cli) in a text editor. Replace occurrences of `reza` with `<your suffix>`. Make sure to switch your FTP client to *binary mode*, if that is not already the default.  Via FTP, upload the JDBC driver to the /site/deployments/tools/ directory. Then upload the jboss_cli_commands.cli, postgresql-module.xml and startup.sh files to the /site/deployments/tools/ directory.
 * In the portal, go to 'All resources'. Find and click on javaee-cafe-web-`<your suffix>`. Go to Configuration -> General settings -> Startup Command. Specify /home/site/deployments/tools/startup.sh as the startup command. Hit save.
 * Go back to the Overview panel and hit restart.
 


### PR DESCRIPTION
modified:   paas/README.md

- No need for text mode in FTP.  Binary mode works for text always.