### PR TITLE
Update the paas example to simplify deployment using the latest azure-webapp-maven-plugin

### DIFF
--- a/paas/README.md
+++ b/paas/README.md
@@ -18,9 +18,7 @@ Once you are done exploring the demo, you should delete the jakartaee-cafe-group
 * Go to the [Azure portal](http://portal.azure.com).
 * Select 'Create a resource'. In the search box, enter and select 'Web App'. Hit create.
 * Enter jakartaee-cafe-web-`<your suffix>` (the suffix could be your first name such as "reza") as application name and select jakartaee-cafe-group-`<your suffix>` as the resource group. Choose Java 11 as your runtime stack and JBoss EAP 7 as the Java web server stack. Hit create.
-* In the portal home, go to 'All resources'. Find and click on the resource named jakartaee-cafe-web-`<your suffix>` of type App Service. Go to the Deployment Center -> FTPS credentials. Note the application scoped FTP access information on this page. Connect with your favorite FTP client using this access information.
-* Go to where this application is on your local machine. Go to the paas directory. Open the [jboss_cli_commands.cli](jboss_cli_commands.cli) in a text editor. Replace occurrences of `reza` with `<your suffix>`. Make sure to switch your FTP client to *binary mode*, if that is not already the default.  Via FTP, upload the JDBC driver to the /site/deployments/tools directory. Make sure to switch to *ASCII mode*. Then upload the jboss_cli_commands.cli and postgresql-module.xml files to the /site/deployments/tools directory as well. Finally, upload the startup.sh file to the root of the FTP path (/).
-* Go back to the Overview panel and hit restart.
+* Go to where this application is on your local machine. Go to the paas directory. Open the file [jboss_cli_commands.cli](jboss_cli_commands.cli) in a text editor. Replace occurrences of `reza` with `<your suffix>`. Also, open the file [pom.xml](pom.xml) in a text editor and update the `azure-webapp-maven-plugin` plugin configuration to point to the right resource group (jakartaee-cafe-group-`<your suffix>`) and web application name (jakartaee-cafe-web-`<your suffix>`).
 
 ## Install the Azure CLI
 * In order to deploy the application, we will need to [install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest).
@@ -38,27 +36,49 @@ The next step is to get the application up and running on managed JBoss EAP. Fol
 * You should note the pom.xml. In particular, we have included the configuration for the Azure Maven plugin we are going to use to deploy the application to managed JBoss EAP:
 
 ```xml
-<plugin>
-    <groupId>com.microsoft.azure</groupId>
-    <artifactId>azure-webapp-maven-plugin</artifactId>
-    <version>2.8.0</version>
-    <configuration>
-        <appName>jakartaee-cafe-web-reza</appName>
-        <resourceGroup>jakartaee-cafe-group-reza</resourceGroup>
-	<javaVersion>Java 11</javaVersion>
-	<webContainer>JBossEAP 7</webContainer>
-	<deployment>
-            <resources>
-                <resource>
-                    <directory>${project.basedir}/target</directory>
-                    <includes>
-                        <include>jakartaee-cafe.war</include>
-                    </includes>
-                </resource>
-            </resources>
-        </deployment>
-    </configuration>
-</plugin>
+            <plugin>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-webapp-maven-plugin</artifactId>
+                <version>2.11.1</version>
+                <configuration>
+                    <appName>jakartaee-cafe-web-reza</appName>
+                    <resourceGroup>jakartaee-cafe-group-reza</resourceGroup>
+                    <javaVersion>Java 11</javaVersion>
+                    <webContainer>JBossEAP 7</webContainer>
+                    <deployment>
+                        <resources>
+                            <resource>
+                                <type>lib</type>
+                                <directory>${project.basedir}/..</directory>
+                                <includes>
+                                    <include>postgresql-42.5.3.jar</include>
+                                </includes>
+                            </resource>
+                            <resource>
+                                <type>script</type>
+                                <directory>${project.basedir}/..</directory>
+                                <includes>
+                                    <include>postgresql-module.xml</include>
+                                    <include>jboss_cli_commands.cli</include>
+                                </includes>
+                            </resource>
+                            <resource>
+                                <type>startup</type>
+                                <directory>${project.basedir}/..</directory>
+                                <includes>
+                                    <include>startup.sh</include>
+                                </includes>
+                            </resource>
+                            <resource>
+                                <directory>${project.basedir}/target</directory>
+                                <includes>
+                                    <include>jakartaee-cafe.war</include>
+                                </includes>
+                            </resource>
+                        </resources>
+                    </deployment>
+                </configuration>
+            </plugin>
 ```
 
 * It is now time to deploy and run the application on Azure. Right click the application -> Run As -> 'Maven build...'. Enter the name as 'Deploy to Azure'. Enter the goals as 'azure-webapp:deploy'. Hit run.

--- a/paas/jakartaee-cafe/pom.xml
+++ b/paas/jakartaee-cafe/pom.xml
@@ -51,27 +51,49 @@
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
             </plugin>
-	        <plugin>
-		    <groupId>com.microsoft.azure</groupId>
-		    <artifactId>azure-webapp-maven-plugin</artifactId>
-		    <version>2.8.0</version>
-		    <configuration>
-		        <appName>jakartaee-cafe-web-reza</appName>
-			<resourceGroup>jakartaee-cafe-group-reza</resourceGroup>
-			<javaVersion>Java 11</javaVersion>
-			<webContainer>JBossEAP 7</webContainer>
-			<deployment>
-                            <resources>
-                                <resource>
-                                    <directory>${project.basedir}/target</directory>
-                                    <includes>
-                                        <include>jakartaee-cafe.war</include>
-                                    </includes>
-                                </resource>
-                            </resources>
-                        </deployment>
-		    </configuration>
-		</plugin>
+            <plugin>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-webapp-maven-plugin</artifactId>
+                <version>2.11.1</version>
+                <configuration>
+                    <appName>jakartaee-cafe-web-reza</appName>
+                    <resourceGroup>jakartaee-cafe-group-reza</resourceGroup>
+                    <javaVersion>Java 11</javaVersion>
+                    <webContainer>JBossEAP 7</webContainer>
+                    <deployment>
+                        <resources>
+                            <resource>
+                                <type>lib</type>
+                                <directory>${project.basedir}/..</directory>
+                                <includes>
+                                    <include>postgresql-42.5.3.jar</include>
+                                </includes>
+                            </resource>
+                            <resource>
+                                <type>script</type>
+                                <directory>${project.basedir}/..</directory>
+                                <includes>
+                                    <include>postgresql-module.xml</include>
+                                    <include>jboss_cli_commands.cli</include>
+                                </includes>
+                            </resource>
+                            <resource>
+                                <type>startup</type>
+                                <directory>${project.basedir}/..</directory>
+                                <includes>
+                                    <include>startup.sh</include>
+                                </includes>
+                            </resource>
+                            <resource>
+                                <directory>${project.basedir}/target</directory>
+                                <includes>
+                                    <include>jakartaee-cafe.war</include>
+                                </includes>
+                            </resource>
+                        </resources>
+                    </deployment>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/paas/jakartaee-cafe/src/main/resources/META-INF/persistence.xml
+++ b/paas/jakartaee-cafe/src/main/resources/META-INF/persistence.xml
@@ -8,7 +8,7 @@
 		<properties>
 			<property
 				name="javax.persistence.schema-generation.database.action"
-				value="create" />
+				value="drop-and-create" />
 			<property name="openjpa.jdbc.SynchronizeMappings"
 				value="buildSchema" />
 			<property name="eclipselink.logging.level.sql" value="FINE" />

--- a/paas/jboss_cli_commands.cli
+++ b/paas/jboss_cli_commands.cli
@@ -1,6 +1,6 @@
 #!/bin/bash
 # These commands are executed by the JBoss CLI.
-module add --name=org.postgresql --resources=/home/site/deployments/tools/postgresql-42.5.3.jar --module-xml=/home/site/deployments/tools/postgresql-module.xml
+module add --name=org.postgresql --resources=/home/site/libs/postgresql-42.5.3.jar --module-xml=/home/site/scripts/postgresql-module.xml
 /subsystem=datasources/jdbc-driver=postgresql:add(driver-name="postgresql",driver-module-name="org.postgresql",driver-class-name="org.postgresql.Driver",driver-xa-datasource-class-name="org.postgresql.xa.PGXADataSource")
 data-source add --name="PostgresqlDS" --driver-name="postgresql" --jndi-name="java:/jdbc/JakartaEECafeDB" --connection-url="jdbc:postgresql://jakartaee-cafe-db-reza.postgres.database.azure.com:5432/postgres" --user-name="postgres@jakartaee-cafe-db-reza" --password="Secret123!" --enabled=true --use-java-context=true
 reload --use-current-server-config=true

--- a/paas/startup.sh
+++ b/paas/startup.sh
@@ -1,2 +1,2 @@
 # This file is executed when your app is started.
-$JBOSS_HOME/bin/jboss-cli.sh --connect --file=/home/site/deployments/tools/jboss_cli_commands.cli
+$JBOSS_HOME/bin/jboss-cli.sh --connect --file=/home/site/scripts/jboss_cli_commands.cli


### PR DESCRIPTION
This PR is an improved version of #5 using the latest version of azure-webapp-maven-plugin now that is capable of deploying artifacts of multiple types, so users don't have to manually upload files through FTP.