### PR TITLE
Update azure-webapp-maven-plugin version, fix configuration

### DIFF
--- a/paas/README.md
+++ b/paas/README.md
@@ -41,12 +41,16 @@ The next step is to get the application up and running on managed JBoss EAP. Fol
 <plugin>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-webapp-maven-plugin</artifactId>
-    <version>2.12.0</version>
+    <version>2.14.1</version>
     <configuration>
         <appName>jakartaee-cafe-web-reza</appName>
         <resourceGroup>jakartaee-cafe-group-reza</resourceGroup>
-        <javaVersion>Java 11</javaVersion>
-        <webContainer>JBossEAP 7</webContainer>
+        <pricingTier>P0v3</pricingTier>
+        <runtime>
+            <os>Linux</os>      
+            <javaVersion>Java 11</javaVersion>
+            <webContainer>JBossEAP 7</webContainer>
+        </runtime>
         <appSettings>
             <!-- Increase the timeout -->
             <property>

--- a/paas/jakartaee-cafe/pom.xml
+++ b/paas/jakartaee-cafe/pom.xml
@@ -60,12 +60,16 @@
             <plugin>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-webapp-maven-plugin</artifactId>
-                <version>2.12.0</version>
+                <version>2.14.1</version>
                 <configuration>
                     <appName>jakartaee-cafe-web-reza</appName>
                     <resourceGroup>jakartaee-cafe-group-reza</resourceGroup>
-                    <javaVersion>Java 11</javaVersion>
-                    <webContainer>JBossEAP 7</webContainer>
+                    <pricingTier>P0v3</pricingTier>
+				    <runtime>
+						<os>Linux</os>      
+						<javaVersion>Java 11</javaVersion>
+						<webContainer>JBossEAP 7</webContainer>
+				    </runtime>
                     <appSettings>
                         <!-- Increase the timeout -->
                         <property>


### PR DESCRIPTION
* Bump the configuration to the latest version of `azure-webapp-maven-plugin`
* Update the configuration (there is a `<runtime>` element inside `<configuration>`, see https://github.com/microsoft/azure-maven-plugins/wiki/Azure-Web-App:-Deploy ). Used the `P0v3` pricingTier because `F1` (free) cannot be used for Java apps with this version of the plugin (it tries to set Always-On, but that's not enabled for the Free tier)